### PR TITLE
Emb Listener, static threads, & metadata drawer

### DIFF
--- a/app/src/main/java/com/embroidermodder/embroideryviewer/ColorStitchAdapter.java
+++ b/app/src/main/java/com/embroidermodder/embroideryviewer/ColorStitchAdapter.java
@@ -13,20 +13,22 @@ import yuku.ambilwarna.AmbilWarnaDialog;
 
 public class ColorStitchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     EmbPattern pattern;
-    static final int COLOR = 0;
-    static final int STITCH = 1;
+    static final int METADATA = 0;
+    static final int COLOR = 1;
+    static final int STITCH = 2;
 
     public ColorStitchAdapter() {
     }
 
     public void setPattern(EmbPattern root) {
         this.pattern = root;
-        this.notifyDataSetChanged();
     }
 
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         switch (viewType) {
+            case METADATA:
+                return new MetaDataViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.color_stitch_stitch_item, parent, false));
             case STITCH:
                 return new ColorStitchStitchViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.color_stitch_stitch_item, parent, false));
             case COLOR:
@@ -38,21 +40,44 @@ public class ColorStitchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
     @Override
     public int getItemViewType(int position) {
-        if (pattern.getThreadCount() > position) return COLOR;
+        if (6 > position) return METADATA;
+        if (pattern.getThreadCount() > (position - 6)) return COLOR;
         return STITCH;
     }
 
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         switch (holder.getItemViewType()) {
+            case METADATA:
+                MetaDataViewHolder mHolder = (MetaDataViewHolder) holder;
+                switch (position) {
+                    case 0:
+                        mHolder.setDataPair(EmbPattern.PROP_FILENAME,pattern.filename);
+                        break;
+                    case 1:
+                        mHolder.setDataPair(EmbPattern.PROP_NAME,pattern.name);
+                        break;
+                    case 2:
+                        mHolder.setDataPair(EmbPattern.PROP_AUTHOR,pattern.author);
+                        break;
+                    case 3:
+                        mHolder.setDataPair(EmbPattern.PROP_CATEGORY,pattern.category);
+                        break;
+                    case 4:
+                        mHolder.setDataPair(EmbPattern.PROP_KEYWORDS,pattern.keywords);
+                        break;
+                    case 5:
+                        mHolder.setDataPair(EmbPattern.PROP_COMMENTS,pattern.comments);
+                }
+                break;
             case STITCH:
                 ColorStitchStitchViewHolder sHolder = (ColorStitchStitchViewHolder) holder;
-                Point p = pattern.getStitches().getPoint(position - pattern.getThreadCount());
+                Point p = pattern.getStitches().getPoint((position - 6) - pattern.getThreadCount());
                 sHolder.setPoint(p);
                 break;
             case COLOR:
                 ColorStitchColorViewHolder cHolder = (ColorStitchColorViewHolder) holder;
-                EmbThread thread = pattern.getThreadList().get(position);
+                EmbThread thread = pattern.getThreadList().get(position-6);
                 cHolder.setThread(thread);
                 break;
         }
@@ -93,6 +118,7 @@ public class ColorStitchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
                         public void onOk(AmbilWarnaDialog dialog, int newColor) {
                             thread.setColor(newColor);
                             notifyItemChanged(getAdapterPosition());
+                            pattern.notifyChange(EmbPattern.NOTIFY_THREAD_COLOR);
                         }
                     });
                     dialog.show();
@@ -153,6 +179,23 @@ public class ColorStitchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
             }
 
         }
+    }
+
+    public class MetaDataViewHolder extends RecyclerView.ViewHolder {
+        TextView value;
+        TextView key;
+
+        public MetaDataViewHolder(View itemView) {
+            super(itemView);
+            value = (TextView) itemView.findViewById(R.id.stitchblock_coords);
+            key = (TextView) itemView.findViewById(R.id.stitchblock_name);
+        }
+
+        public void setDataPair(String key, String value) {
+            this.key.setText(key);
+            this.value.setText(value);
+        }
+
     }
 
     private class EmptyViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/com/embroidermodder/embroideryviewer/ColorStitchBlockFragment.java
+++ b/app/src/main/java/com/embroidermodder/embroideryviewer/ColorStitchBlockFragment.java
@@ -11,7 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 
-public class ColorStitchBlockFragment extends Fragment implements DrawView.Listener {
+public class ColorStitchBlockFragment extends Fragment implements EmbPattern.Listener {
     public static final String TAG = "ColorStitch";
     private ColorStitchAdapter adapter;
     private RecyclerView recyclerColorStitch;
@@ -27,15 +27,14 @@ public class ColorStitchBlockFragment extends Fragment implements DrawView.Liste
 
     public void setPattern(EmbPattern pattern) {
         if (pattern != null) {
+            pattern.addListener(this);
             if (adapter == null) {
                 adapter = new ColorStitchAdapter();
                 adapter.setPattern(pattern);
                 recyclerColorStitch.setAdapter(adapter);
-            }
-            else {
+            } else {
                 adapter.setPattern(pattern);
             }
-
 
         }
     }
@@ -46,13 +45,20 @@ public class ColorStitchBlockFragment extends Fragment implements DrawView.Liste
         recyclerColorStitch = (RecyclerView) view.findViewById(R.id.recyclerColorStitch);
         Context context = view.getContext();
         recyclerColorStitch.setLayoutManager(new LinearLayoutManager(context));
-        if (getActivity() instanceof MainActivity) {
-            setPattern(((MainActivity) getActivity()).getPattern());
+        if (getActivity() instanceof EmbPattern.Provider) {
+            setPattern(((EmbPattern.Provider) getActivity()).getPattern());
         }
     }
 
     @Override
     public void notifyChange(int id) {
-        adapter.notifyDataSetChanged();
+        if (id == EmbPattern.NOTIFY_CHANGE) {
+            if (getActivity() instanceof EmbPattern.Provider) {
+                setPattern(((EmbPattern.Provider) getActivity()).getPattern());
+            }
+            adapter.notifyDataSetChanged();
+        } else {
+            adapter.notifyDataSetChanged();
+        }
     }
 }

--- a/app/src/main/java/com/embroidermodder/embroideryviewer/EmbPatternViewer.java
+++ b/app/src/main/java/com/embroidermodder/embroideryviewer/EmbPatternViewer.java
@@ -10,15 +10,20 @@ import android.graphics.RectF;
 import com.embroidermodder.embroideryviewer.geom.DataPoints;
 
 import java.util.ArrayList;
-import java.util.Random;
 
 public class EmbPatternViewer extends ArrayList<StitchBlock> {
     EmbPattern pattern;
 
     private static final float PIXELS_PER_MM = 10;
 
+
     public EmbPatternViewer(EmbPattern pattern) {
         this.pattern = pattern;
+        refresh();
+    }
+
+    public void refresh() {
+        clear();
         int threadIndex = 0;
         DataPoints stitches = pattern.getStitches();
         int start;
@@ -44,19 +49,11 @@ public class EmbPatternViewer extends ArrayList<StitchBlock> {
                 int data = stitches.getData(i);
                 if (data != IFormat.NORMAL) {
                     stop = i;
-                    add(new StitchBlock(stitches, start, stop, getThread(threadIndex), 0));
+                    add(new StitchBlock(stitches, start, stop, pattern.getThreadOrFiller(threadIndex), 0));
                     break;
                 }
             }
         } while ((stop != -1) && (start != stop));
-    }
-
-    public EmbThread getThread(int threadIndex) {
-        if (pattern.getThreadList().size() <= threadIndex) {
-            Random r = new Random();
-            return new EmbThread(0xFF000000 | r.nextInt(0xFFFFFF), "Random");
-        }
-        return pattern.getThread(threadIndex);
     }
 
     public Bitmap getThumbnail(float _width, float _height) {

--- a/app/src/main/java/com/embroidermodder/embroideryviewer/FormatJef.java
+++ b/app/src/main/java/com/embroidermodder/embroideryviewer/FormatJef.java
@@ -251,7 +251,7 @@ public class FormatJef implements IFormat.Reader, IFormat.Writer {
         }
         pattern.getFlippedPattern(false, true);
         pattern.addStitchRel(0, 0, IFormat.END, true);
-        //pattern.rel_flip(1);
+        pattern.rel_flip(1);
     }
 
     private void encode(byte[] b, byte dx, byte dy, int flags) {
@@ -391,7 +391,7 @@ public class FormatJef implements IFormat.Reader, IFormat.Writer {
             }
             stream.write(0x80);
             stream.write(0x10);
-            //pattern.rel_flip(1);
+            pattern.rel_flip(1);
             stream.close();
         } catch (IOException ex) {
         }


### PR DESCRIPTION
Setup a listener for EmbPattern, also set it in DrawView to be final and added some code to make sure it could always be simply updated without change the reference. It's at times confusing but other times saves you from a lot of headache trying to find which EmbPattern is being listened to.

Added metadata to the colorstitch fragment.

The EmbThread code getThreadOrRandom is changed to getThreadOrFiller and just calls the FormatPec.getThread() function for values less than 60.